### PR TITLE
feat: add enable alert option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ make build
 
 ```
 "alert_config": {
-  "interval": 300
-  "identity": your_bot_identity
-  "telegram_bot_id": your_bot_id
+  "enable_alert": false,
+  "identity": your_bot_identity,
+  "telegram_bot_id": your_bot_id,
   "telegram_chat_id": your_chat_id  
 }
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -100,6 +100,7 @@ func ParseConfigFromFile(filePath string) *Config {
 }
 
 type AlertConfig struct {
+	EnableAlert    bool   `json:"enable_alert"`
 	Identity       string `json:"identity"`
 	TelegramBotId  string `json:"telegram_bot_id"`
 	TelegramChatId string `json:"telegram_chat_id"`

--- a/config/config.json
+++ b/config/config.json
@@ -33,6 +33,7 @@
     "db_path": "root:root@tcp(127.0.0.1:3306)/challenger?charset=utf8&parseTime=True&loc=Local"
   },
   "alert_config": {
+    "enable_alert": true,
     "interval": 300,
     "identity": "your_identity",
     "telegram_bot_id": "your_bot_id",

--- a/config/config.json
+++ b/config/config.json
@@ -33,7 +33,7 @@
     "db_path": "root:root@tcp(127.0.0.1:3306)/challenger?charset=utf8&parseTime=True&loc=Local"
   },
   "alert_config": {
-    "enable_alert": true,
+    "enable_alert": false,
     "interval": 300,
     "identity": "your_identity",
     "telegram_bot_id": "your_bot_id",

--- a/submitter/tx_submitter.go
+++ b/submitter/tx_submitter.go
@@ -106,7 +106,9 @@ func (s *TxSubmitter) submitForSingleEvent(event *model.Event) error {
 		case <-ticker.C:
 			triedTimes++
 			if triedTimes > SubmitTxMaxRetry {
-				alert.SendTelegramMessage(s.config.AlertConfig.Identity, s.config.AlertConfig.TelegramChatId, s.config.AlertConfig.TelegramBotId, fmt.Sprintf("failed to submit tx for challenge after retry, id: %d", event.ChallengeId))
+				if s.config.AlertConfig.EnableAlert {
+					alert.SendTelegramMessage(s.config.AlertConfig.Identity, s.config.AlertConfig.TelegramChatId, s.config.AlertConfig.TelegramBotId, fmt.Sprintf("failed to submit tx for challenge after retry, id: %d", event.ChallengeId))
+				}
 				logging.Logger.Infof("failed to submit tx for challenge after retry, id: %d", event.ChallengeId)
 				return s.UpdateEventStatus(event.ChallengeId, model.SubmitFailed)
 			}

--- a/vote/vote_processor.go
+++ b/vote/vote_processor.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/bnb-chain/greenfield-challenger/alert"
 
-	"github.com/avast/retry-go/v4"
 	"github.com/bnb-chain/greenfield-challenger/common"
 	"github.com/bnb-chain/greenfield-challenger/config"
 	"github.com/bnb-chain/greenfield-challenger/db/dao"
@@ -192,7 +191,9 @@ func (p *VoteProcessor) queryMoreThanTwoThirdVotesForEvent(event *model.Event, v
 	for {
 		// skip current tx if reach the max retry.
 		if triedTimes > QueryVotepoolMaxRetry {
-			alert.SendTelegramMessage(p.config.AlertConfig.Identity, p.config.AlertConfig.TelegramChatId, p.config.AlertConfig.TelegramBotId, fmt.Sprintf("failed to collect votes for challenge after retry, id: %d", event.ChallengeId))
+			if p.config.AlertConfig.EnableAlert {
+				alert.SendTelegramMessage(p.config.AlertConfig.Identity, p.config.AlertConfig.TelegramChatId, p.config.AlertConfig.TelegramBotId, fmt.Sprintf("failed to collect votes for challenge after retry, id: %d", event.ChallengeId))
+			}
 			logging.Logger.Infof("failed to collect votes for challenge after retry, id: %d", event.ChallengeId)
 			return p.UpdateEventStatus(event.ChallengeId, model.NoEnoughVotesCollected)
 		}

--- a/vote/vote_processor.go
+++ b/vote/vote_processor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/avast/retry-go/v4"
 	"time"
 
 	"github.com/bnb-chain/greenfield-challenger/alert"


### PR DESCRIPTION
### Description

The option allows the users to turn alerts on/off  

### Rationale

This allows the users to turn the alerts off if they don't require it

### Example

none

### Changes

changes to config file and read.me  
changes to existing functions that are using the alert  