### PR TITLE
fix: out of range error for querying cached validators 

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -153,9 +153,8 @@ func (e *Executor) queryLatestValidators() ([]*tmtypes.Validator, error) {
 }
 
 func (e *Executor) QueryCachedLatestValidators() ([]*tmtypes.Validator, error) {
-	result := make([]*tmtypes.Validator, 0)
-
 	e.mtx.Lock()
+	result := make([]*tmtypes.Validator, len(e.validators))
 	if len(e.validators) > 0 {
 		for i, p := range e.validators {
 			v := *p


### PR DESCRIPTION
### Description

The program was returning out of range errors due to the cached validator array being initiated with length 0  

### Rationale

Can't query cached validators without the fix  

### Example

none  

### Changes

Notable changes: 
executor  