### PR TITLE
release: draft release v0.0.2-alpha.1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## v0.0.1-alpha.1
+## v0.0.2-alpha.1
 This is a pre-release. The go-sdk module and it's relevant dependencies are updated to use their pre-release alpha versions.
 * [#44](https://github.com/bnb-chain/greenfield-challenger/pull/44) chore: upgrade dependencies    
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v0.0.1-alpha.1
+This is a pre-release. The go-sdk module and it's relevant dependencies are updated to use their pre-release alpha versions.
+* [#44](https://github.com/bnb-chain/greenfield-challenger/pull/44) chore: upgrade dependencies    
+
 ## v0.0.1
 This release launches the Challenger Service.
 


### PR DESCRIPTION
### Description

This is a pre-release. The go-sdk module and it's relevant dependencies are updated to use their pre-release alpha versions.

### Rationale

Changelog:  
* [#44](https://github.com/bnb-chain/greenfield-challenger/pull/44) chore: upgrade dependencies      

### Example

Please refer to detailed PRs

### Changes

Notable changes: 
* There are no notable changes  
