### PR TITLE
release: draft release for v0.0.2  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## v0.0.2
+This is a maintenance release that updates the service to adapt to it's updated dependencies and code refactoring.
+* [#47](https://github.com/bnb-chain/greenfield-challenger/pull/47) feat: adapt to new go-sdk and greenfield version
+
 ## v0.0.2-alpha.1
 This is a pre-release. The go-sdk module and it's relevant dependencies are updated to use their pre-release alpha versions.
 * [#44](https://github.com/bnb-chain/greenfield-challenger/pull/44) chore: upgrade dependencies    


### PR DESCRIPTION
### Description

This is a maintenance release that updates the service to adapt to it's updated dependencies and code refactoring.    

### Rationale
Change log:  
* [#47](https://github.com/bnb-chain/greenfield-challenger/pull/47) feat: adapt to new go-sdk and greenfield version  

### Example

Please refer to detailed PRs

### Changes

Notable changes: 
* There are no notable changes  
