### PR TITLE
fix: remove bucketdeleted status from verifystatus and place in eventstatus instead  

### DIFF
--- a/attest/attest_monitor.go
+++ b/attest/attest_monitor.go
@@ -36,7 +36,6 @@ func (a *AttestMonitor) UpdateAttestedChallengeIdLoop() {
 			logging.Logger.Errorf("update latest attested challenge error, err=%+v", err)
 			continue
 		}
-		logging.Logger.Infof("latest attested challenge ids: %+v", challengeIds)
 		a.mtx.Lock()
 		a.updateAttestedCacheAndEventStatus(a.attestedChallengeIds, challengeIds)
 		for _, id := range challengeIds {

--- a/db/model/event.go
+++ b/db/model/event.go
@@ -43,6 +43,7 @@ const (
 	SelfAttested
 	Attested // Event has been submitted for tx
 	Duplicated
+	BucketDeleted
 )
 
 type VerifyResult int
@@ -51,5 +52,4 @@ const (
 	Unknown        VerifyResult = iota // Event not been verified
 	HashMatched                        // The challenge failed, hashes are matched
 	HashMismatched                     // The challenge succeed, hashed are not matched
-	BucketDeleted
 )

--- a/verifier/hash_verifier.go
+++ b/verifier/hash_verifier.go
@@ -143,7 +143,7 @@ func (v *Verifier) verifyForSingleEvent(event *model.Event) error {
 			logging.Logger.Errorf("error getting challenge result from sp for challengeId: %d, objectId: %s, err=%s", event.ChallengeId, event.ObjectId, err.Error())
 			// TODO: Create error code list for SP side
 			if strings.Contains(err.Error(), "35201") {
-				err := v.dataProvider.UpdateEventStatusVerifyResult(event.ChallengeId, model.Verified, model.BucketDeleted)
+				err := v.dataProvider.UpdateEventStatusVerifyResult(event.ChallengeId, model.BucketDeleted, model.Unknown)
 				return err
 			}
 			err := v.dataProvider.UpdateEventStatusVerifyResult(event.ChallengeId, model.Verified, model.HashMismatched)


### PR DESCRIPTION
### Description

Resolve an error that was caused by placing the BucketDeleted status in VerifyStatus  

### Rationale

It was causing the service to crash since it couldn't create votes based on that particular status  

### Example

none

### Changes

Notable changes: 
none  
