### PR TITLE
release: draft release for v0.0.2-hotfix  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.2-hotfix  
+This is a hotfix release that resolves a bug that was caused by an invalid verification status.
+* [#51](https://github.com/bnb-chain/greenfield-challenger/pull/51) fix: remove bucketdeleted status from verifystatus and place in eventstatus instead  
+
 ## v0.0.2
 This is a maintenance release that updates the service to adapt to it's updated dependencies and code refactoring.
 * [#47](https://github.com/bnb-chain/greenfield-challenger/pull/47) feat: adapt to new go-sdk and greenfield version


### PR DESCRIPTION
### Description

This is a hotfix release that resolves a bug that was caused by an invalid verification status.

### Rationale

* [#51](https://github.com/bnb-chain/greenfield-challenger/pull/51) fix: remove bucketdeleted status from verifystatus and place in eventstatus instead  

### Example

Please refer to the PRs for detailed information.  

### Changes

Notable changes: 
none   