### PR TITLE
fix: remove bucketdeleted status

### DIFF
--- a/attest/attest_monitor.go
+++ b/attest/attest_monitor.go
@@ -36,7 +36,6 @@ func (a *AttestMonitor) UpdateAttestedChallengeIdLoop() {
 			logging.Logger.Errorf("update latest attested challenge error, err=%+v", err)
 			continue
 		}
-		logging.Logger.Infof("latest attested challenge ids: %+v", challengeIds)
 		a.mtx.Lock()
 		a.updateAttestedCacheAndEventStatus(a.attestedChallengeIds, challengeIds)
 		for _, id := range challengeIds {

--- a/db/model/event.go
+++ b/db/model/event.go
@@ -51,5 +51,4 @@ const (
 	Unknown        VerifyResult = iota // Event not been verified
 	HashMatched                        // The challenge failed, hashes are matched
 	HashMismatched                     // The challenge succeed, hashed are not matched
-	BucketDeleted
 )

--- a/verifier/hash_verifier.go
+++ b/verifier/hash_verifier.go
@@ -142,10 +142,6 @@ func (v *Verifier) verifyForSingleEvent(event *model.Event) error {
 		if err != nil {
 			logging.Logger.Errorf("error getting challenge result from sp for challengeId: %d, objectId: %s, err=%s", event.ChallengeId, event.ObjectId, err.Error())
 			// TODO: Create error code list for SP side
-			if strings.Contains(err.Error(), "35201") {
-				err := v.dataProvider.UpdateEventStatusVerifyResult(event.ChallengeId, model.Verified, model.BucketDeleted)
-				return err
-			}
 			err := v.dataProvider.UpdateEventStatusVerifyResult(event.ChallengeId, model.Verified, model.HashMismatched)
 			return err
 		}


### PR DESCRIPTION
### Description

this status is no longer required  

### Rationale

cleanup unused status  

### Example

none   

### Changes

Notable changes: 
none  
