### PR TITLE
fix: attest monitor missing attested challenges

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -83,7 +83,7 @@ func NewApp(cfg *config.Config) *App {
 	monitor := monitor.NewMonitor(executor, monitorDataHandler, metricService)
 
 	verifierDataHandler := verifier.NewDataHandler(daoManager)
-	hashVerifier := verifier.NewHashVerifier(cfg, executor, cfg.GreenfieldConfig.DeduplicationInterval, verifierDataHandler, metricService)
+	hashVerifier := verifier.NewHashVerifier(cfg, executor, verifierDataHandler, metricService)
 
 	signer := vote.NewVoteSigner(executor.BlsPrivKey)
 	voteDataHandler := vote.NewDataHandler(daoManager, executor)

--- a/config/config.go
+++ b/config/config.go
@@ -17,18 +17,17 @@ type Config struct {
 }
 
 type GreenfieldConfig struct {
-	KeyType               string   `json:"key_type"`
-	AWSRegion             string   `json:"aws_region"`
-	AWSSecretName         string   `json:"aws_secret_name"`
-	AWSBlsSecretName      string   `json:"aws_bls_secret_name"`
-	PrivateKey            string   `json:"private_key"`
-	BlsPrivateKey         string   `json:"bls_private_key"`
-	RPCAddrs              []string `json:"rpc_addrs"`
-	ChainIdString         string   `json:"chain_id_string"`
-	GasLimit              uint64   `json:"gas_limit"`
-	FeeAmount             string   `json:"fee_amount"`
-	FeeDenom              string   `json:"fee_denom"`
-	DeduplicationInterval uint64   `json:"deduplication_interval"`
+	KeyType          string   `json:"key_type"`
+	AWSRegion        string   `json:"aws_region"`
+	AWSSecretName    string   `json:"aws_secret_name"`
+	AWSBlsSecretName string   `json:"aws_bls_secret_name"`
+	PrivateKey       string   `json:"private_key"`
+	BlsPrivateKey    string   `json:"bls_private_key"`
+	RPCAddrs         []string `json:"rpc_addrs"`
+	ChainIdString    string   `json:"chain_id_string"`
+	GasLimit         uint64   `json:"gas_limit"`
+	FeeAmount        string   `json:"fee_amount"`
+	FeeDenom         string   `json:"fee_denom"`
 }
 
 func (cfg *GreenfieldConfig) Validate() {
@@ -69,9 +68,6 @@ func (cfg *GreenfieldConfig) Validate() {
 	}
 	if cfg.FeeDenom == "" {
 		panic("fee_denom should not be empty")
-	}
-	if cfg.DeduplicationInterval == 0 {
-		panic("deduplication_interval should not be 0")
 	}
 	feeAmount, ok := math.NewIntFromString(cfg.FeeAmount)
 	if !ok {

--- a/db/model/event.go
+++ b/db/model/event.go
@@ -43,6 +43,7 @@ const (
 	SelfAttested
 	Attested // Event has been submitted for tx
 	Duplicated
+	DuplicatedSlash
 )
 
 type VerifyResult int

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -294,6 +294,7 @@ func (e *Executor) QueryChallengeSlashCoolingOffPeriod() (uint64, error) {
 		logging.Logger.Errorf("query challenge params failed, err=%+v", err.Error())
 		return 0, err
 	}
+	logging.Logger.Infof("challenge slash cooling off period: %d", params.Params.SlashCoolingOffPeriod)
 	return params.Params.SlashCoolingOffPeriod, nil
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -287,6 +287,16 @@ func (e *Executor) QueryChallengeHeartbeatInterval() (uint64, error) {
 	return heartbeatInterval, nil
 }
 
+func (e *Executor) QueryChallengeSlashCoolingOffPeriod() (uint64, error) {
+	client := e.clients.GetClient().Client
+	params, err := client.ChallengeParams(context.Background(), &challengetypes.QueryParamsRequest{})
+	if err != nil {
+		logging.Logger.Errorf("query challenge params failed, err=%+v", err.Error())
+		return 0, err
+	}
+	return params.Params.SlashCoolingOffPeriod, nil
+}
+
 func (e *Executor) UpdateHeartbeatIntervalLoop() {
 	ticker := time.NewTicker(QueryHeartbeatIntervalInterval)
 	for range ticker.C {

--- a/submitter/tx_submitter.go
+++ b/submitter/tx_submitter.go
@@ -4,6 +4,7 @@ import (
 	"cosmossdk.io/math"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bnb-chain/greenfield-challenger/common"
@@ -160,6 +161,7 @@ func (s *TxSubmitter) submitTransactionLoop(event *model.Event, attestPeriodEnd 
 		}
 
 		if submittedAttempts > common.MaxSubmitAttempts {
+			s.metricService.IncSubmitterErr()
 			return fmt.Errorf("submitter exceeded max submit attempts for challengeId: %d", event.ChallengeId)
 		}
 
@@ -183,12 +185,20 @@ func (s *TxSubmitter) submitTransactionLoop(event *model.Event, attestPeriodEnd 
 		// Submit transaction
 		attestRes, err := s.executor.AttestChallenge(s.executor.GetAddr(), event.ChallengerAddress, event.SpOperatorAddress, event.ChallengeId, math.NewUintFromString(event.ObjectId), voteResult, valBitSet.Bytes(), aggregatedSignature, txOpts)
 		if err != nil || !attestRes {
+			// Handle cases where the challenge wasn't successfully attested but no error was returned
 			if err != nil {
 				logging.Logger.Errorf("submitter failed for challengeId: %d, attempts: %d, err=%+v", event.ChallengeId, submittedAttempts, err.Error())
+				// Handle cases where a storage provider was recently slashed
+				if strings.Contains(err.Error(), "duplicated slash") {
+					dbErr := s.DataProvider.UpdateEventStatus(event.ChallengeId, model.DuplicatedSlash)
+					if dbErr != nil {
+						return dbErr
+					}
+					return err
+				}
 			} else {
 				logging.Logger.Errorf("submitter failed for challengeId: %d, attempts: %d", event.ChallengeId, submittedAttempts)
 			}
-			s.metricService.IncSubmitterErr()
 			submittedAttempts++
 			time.Sleep(TxSubmitInterval)
 			continue
@@ -196,7 +206,6 @@ func (s *TxSubmitter) submitTransactionLoop(event *model.Event, attestPeriodEnd 
 		// Update event status to include in Attest Monitor
 		err = s.DataProvider.UpdateEventStatus(event.ChallengeId, model.Submitted)
 		if err != nil {
-			s.metricService.IncSubmitterErr()
 			logging.Logger.Errorf("submitter succeeded in attesting but failed to update database, err=%+v", err.Error())
 			continue
 		}

--- a/submitter/tx_submitter.go
+++ b/submitter/tx_submitter.go
@@ -185,6 +185,8 @@ func (s *TxSubmitter) submitTransactionLoop(event *model.Event, attestPeriodEnd 
 		if err != nil || !attestRes {
 			if err != nil {
 				logging.Logger.Errorf("submitter failed for challengeId: %d, attempts: %d, err=%+v", event.ChallengeId, submittedAttempts, err.Error())
+			} else {
+				logging.Logger.Errorf("submitter failed for challengeId: %d, attempts: %d", event.ChallengeId, submittedAttempts)
 			}
 			s.metricService.IncSubmitterErr()
 			submittedAttempts++

--- a/submitter/tx_submitter.go
+++ b/submitter/tx_submitter.go
@@ -183,8 +183,10 @@ func (s *TxSubmitter) submitTransactionLoop(event *model.Event, attestPeriodEnd 
 		// Submit transaction
 		attestRes, err := s.executor.AttestChallenge(s.executor.GetAddr(), event.ChallengerAddress, event.SpOperatorAddress, event.ChallengeId, math.NewUintFromString(event.ObjectId), voteResult, valBitSet.Bytes(), aggregatedSignature, txOpts)
 		if err != nil || !attestRes {
+			if err != nil {
+				logging.Logger.Errorf("submitter failed for challengeId: %d, attempts: %d, err=%+v", event.ChallengeId, submittedAttempts, err.Error())
+			}
 			s.metricService.IncSubmitterErr()
-			logging.Logger.Errorf("submitter failed for challengeId: %d, attempts: %d, err=%+v", event.ChallengeId, submittedAttempts, err.Error())
 			submittedAttempts++
 			time.Sleep(TxSubmitInterval)
 			continue

--- a/verifier/hash_verifier.go
+++ b/verifier/hash_verifier.go
@@ -260,13 +260,13 @@ func (v *Verifier) computeRootHash(segmentIndex uint32, pieceData []byte, checks
 func (v *Verifier) compareHashAndUpdate(challengeId uint64, chainRootHash []byte, spRootHash []byte) error {
 	if bytes.Equal(chainRootHash, spRootHash) {
 		// TODO: Revert this if debugging
-		err := v.dataProvider.UpdateEventStatusVerifyResult(challengeId, model.Verified, model.HashMismatched)
+		err := v.dataProvider.UpdateEventStatusVerifyResult(challengeId, model.Verified, model.HashMatched)
 		if err != nil {
 			return err
 		}
 		// update metrics if no err
 		v.metricService.IncVerifiedChallenges()
-		v.metricService.IncChallengeSuccess()
+		v.metricService.IncChallengeFailed()
 		return err
 	}
 	err := v.dataProvider.UpdateEventStatusVerifyResult(challengeId, model.Verified, model.HashMismatched)

--- a/verifier/hash_verifier_test.go
+++ b/verifier/hash_verifier_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestHashing(t *testing.T) {
-	verifier := NewHashVerifier(nil, nil, 100, nil, nil)
+	verifier := NewHashVerifier(nil, nil, nil, nil)
 
 	hashesStr := []string{"test1", "test2", "test3", "test4", "test5", "test6", "test7"}
 	checksums := make([][]byte, 7)


### PR DESCRIPTION
### Description

The inturn submitter might change after a challenge is submitted but not confirmed to be attested, resulting in the next submitter to submit the same challenge.  

### Rationale

To update the event status correctly.  

### Example

none  

### Changes
Added a new event status for DuplicatedSlash. Stop attempting to submit if recently submitted.  

Notable changes: 
none  
