### PR TITLE
fixed default value checking issue for metric port

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -130,7 +130,7 @@ type MetricsConfig struct {
 }
 
 func (cfg *MetricsConfig) Validate() {
-	if cfg.Port <= 0 || cfg.Port > 65535 {
+	if cfg.Port < 0 || cfg.Port > 65535 {
 		panic("port should be within (0, 65535]")
 	}
 }


### PR DESCRIPTION
### Description

If config file have no Metric config, the metric port value will be 0
if value is 0, MetricsConfig's Validate will not pass,  raise panic


### Rationale

changed check ranger to <0 will avoid crash 

