### PR TITLE
chore: update challenge api to v2 version

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -355,7 +355,8 @@ func (e *Executor) GetChallengeResultFromSp(objectId, endpoint string, segmentIn
 	client := e.clients.GetClient().Client
 
 	challengeInfoOpts := types.GetChallengeInfoOptions{
-		Endpoint: endpoint,
+		Endpoint:     endpoint,
+		UseV2version: true,
 	}
 	challengeInfo, err := client.GetChallengeInfo(context.Background(), objectId, segmentIndex, redundancyIndex, challengeInfoOpts)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	cosmossdk.io/math v1.0.1
 	github.com/avast/retry-go/v4 v4.3.1
 	github.com/aws/aws-sdk-go v1.40.45
-	github.com/bnb-chain/greenfield v0.2.5
+	github.com/bnb-chain/greenfield v1.0.0
 	github.com/bnb-chain/greenfield-common/go v0.0.0-20230830120314-a54ffd6da39f
-	github.com/bnb-chain/greenfield-go-sdk v0.2.5
+	github.com/bnb-chain/greenfield-go-sdk v1.0.1-0.20231018095259-639d2c1b9826
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/ethereum/go-ethereum v1.10.26

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/avast/retry-go/v4 v4.3.1
 	github.com/aws/aws-sdk-go v1.40.45
 	github.com/bnb-chain/greenfield v1.0.0
-	github.com/bnb-chain/greenfield-common/go v0.0.0-20230830120314-a54ffd6da39f
-	github.com/bnb-chain/greenfield-go-sdk v1.0.1-0.20231018095259-639d2c1b9826
+	github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228
+	github.com/bnb-chain/greenfield-go-sdk v1.0.1-0.20231019022055-c79a6567097e
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/ethereum/go-ethereum v1.10.26

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 h1:41iFGWnSlI2
 github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/greenfield v0.2.5 h1:AmHvGfJmHm7FXB4II4mAB6i68bw98p86ZlIs9r6YeRM=
-github.com/bnb-chain/greenfield v0.2.5/go.mod h1:nNsy8QGR8+R0j6Qz/duNE94NDDNuomC6wWDCzfl7jKc=
+github.com/bnb-chain/greenfield v1.0.0 h1:eg8jFKfbM8ZBKYJ40MZvZtJMtbIcM17tnd7OvAoMC7g=
+github.com/bnb-chain/greenfield v1.0.0/go.mod h1:HAUcv20wBECrbyvVvtoAgvpeedr6plgz3m75FJ7Xxdg=
 github.com/bnb-chain/greenfield-cometbft v0.0.3 h1:tv8NMy3bzX/1urqXGQIIAZSLy83loiI+dG0VKeyh1CY=
 github.com/bnb-chain/greenfield-cometbft v0.0.3/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
@@ -180,8 +180,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e21
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210/go.mod h1:vhsZxXE9tYJeYB5JR4hPhd6Pc/uPf7j1T8IJ7p9FdeM=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210 h1:FLVOn4+OVbsKi2+YJX5kmD27/4dRu4FW7xCXFhzDO5s=
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210/go.mod h1:An0MllWJY6PxibUpnwGk8jOm+a/qIxlKmL5Zyp9NnaM=
-github.com/bnb-chain/greenfield-go-sdk v0.2.5 h1:ErI7nUtNCRDvpXSVaG/XKXEBhTcmiofg/2ciKU1uBag=
-github.com/bnb-chain/greenfield-go-sdk v0.2.5/go.mod h1:rWI9Xgcto7ujajNfG6x7+lW1SzbJWBkIgnOcoNjWS7U=
+github.com/bnb-chain/greenfield-go-sdk v1.0.1-0.20231018095259-639d2c1b9826 h1:zMubcPjB1lKDLRToqSc6k9x1IlcL8UfWAF0881gBlwQ=
+github.com/bnb-chain/greenfield-go-sdk v1.0.1-0.20231018095259-639d2c1b9826/go.mod h1:/VDQfd7KMa5Kl1bBA9XZ9Fq8NZJ5i8bXev0shIZfy+E=
 github.com/bnb-chain/greenfield-iavl v0.20.1 h1:y3L64GU99otNp27/xLVBTDbv4eroR6CzoYz0rbaVotM=
 github.com/bnb-chain/greenfield-iavl v0.20.1/go.mod h1:oLksTs8dfh7DYIKBro7hbRQ+ewls7ghJ27pIXlbEXyI=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
 github.com/bnb-chain/greenfield-common/go v0.0.0-20230830120314-a54ffd6da39f h1:zJvB2wCd80DQ9Nh/ZNQiP8MrHygSpDoav7OzHyIi/pM=
 github.com/bnb-chain/greenfield-common/go v0.0.0-20230830120314-a54ffd6da39f/go.mod h1:it3JJVHeG9Wp4QED2GkY/7V9Qo3BuPdoC5/4/U6ecJM=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228 h1:WywBaew30hZuqDTOQbkRV3uBg6XHjNIE1s3AXVXbG+8=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228/go.mod h1:K9jK80fbahciC+FAvrch8Qsbw9ZkvVgjfKsqrzPTAVA=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.5 h1:8zIn/ExfMHZVBbVwhILG9KYO1m3pZO8I8stpqbFgzkk=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.5/go.mod h1:y3hDhQhil5hMIhwBTpu07RZBF30ZITkoE+GHhVZChtY=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210 h1:GHPbV2bC+gmuO6/sG0Tm8oGal3KKSRlyE+zPscDjlA8=
@@ -182,6 +184,8 @@ github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e2
 github.com/bnb-chain/greenfield-cosmos-sdk/math v0.0.0-20230816082903-b48770f5e210/go.mod h1:An0MllWJY6PxibUpnwGk8jOm+a/qIxlKmL5Zyp9NnaM=
 github.com/bnb-chain/greenfield-go-sdk v1.0.1-0.20231018095259-639d2c1b9826 h1:zMubcPjB1lKDLRToqSc6k9x1IlcL8UfWAF0881gBlwQ=
 github.com/bnb-chain/greenfield-go-sdk v1.0.1-0.20231018095259-639d2c1b9826/go.mod h1:/VDQfd7KMa5Kl1bBA9XZ9Fq8NZJ5i8bXev0shIZfy+E=
+github.com/bnb-chain/greenfield-go-sdk v1.0.1-0.20231019022055-c79a6567097e h1:qJ7vZh9fmN5aBpnNuf33WQgfKyuNsy2YVEGJjcEmkTo=
+github.com/bnb-chain/greenfield-go-sdk v1.0.1-0.20231019022055-c79a6567097e/go.mod h1:UQ1OLlja9gUQ919nxZTURtgmXUkXn9Vgc9A2UMx4taA=
 github.com/bnb-chain/greenfield-iavl v0.20.1 h1:y3L64GU99otNp27/xLVBTDbv4eroR6CzoYz0rbaVotM=
 github.com/bnb-chain/greenfield-iavl v0.20.1/go.mod h1:oLksTs8dfh7DYIKBro7hbRQ+ewls7ghJ27pIXlbEXyI=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=


### PR DESCRIPTION
### Description

Update go-sdk to use challenge v2 version.

### Rationale

Update api

### Example

NA

### Changes

Notable changes: 
* use v2 chellange api