### PR TITLE
fix: fix error with get latest block

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -146,7 +146,7 @@ func (e *Executor) GetLatestBlockHeight() (uint64, error) {
 	return latestHeight, nil
 }
 
-func (e *Executor) GetCachedBlockHeight() (latestHeight uint64) {
+func (e *Executor) GetCachedBlockHeight() uint64 {
 	e.mtx.Lock()
 	cachedHeight := e.height
 	e.mtx.Unlock()

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -134,11 +134,12 @@ func (e *Executor) GetBlockAndBlockResultAtHeight(height int64) (*tmtypes.Block,
 func (e *Executor) GetLatestBlockHeight() (uint64, error) {
 	client := e.clients.GetClient()
 	res, err := client.GetLatestBlockHeight(context.Background())
-	latestHeight := uint64(res)
 	if err != nil {
 		logging.Logger.Errorf("executor failed to get latest block height, err=%s", err.Error())
+		return 0, err
 	}
 
+	latestHeight := uint64(res)
 	e.mtx.Lock()
 	e.height = latestHeight
 	e.mtx.Unlock()


### PR DESCRIPTION
### Description

Fix error with get latest block  

### Rationale

It was causing some issues with fetching events from db  

### Example

none  

### Changes

Notable changes: 
none  
