### PR TITLE
fix: precheck not correctly handling cases where duplicated slashing is found  

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -3,3 +3,4 @@ package common
 import "fmt"
 
 var ErrEventExpired = fmt.Errorf("event expired")
+var ErrDuplicatedSlashing = fmt.Errorf("duplicated slashing")

--- a/verifier/hash_verifier.go
+++ b/verifier/hash_verifier.go
@@ -286,7 +286,8 @@ func (v *Verifier) preCheck(event *model.Event, currentHeight uint64) error {
 			return err
 		}
 		if found {
-			return v.dataProvider.UpdateEventStatus(event.ChallengeId, model.Duplicated)
+			_ = v.dataProvider.UpdateEventStatus(event.ChallengeId, model.Duplicated)
+			return common.ErrDuplicatedSlashing
 		}
 	}
 


### PR DESCRIPTION
### Description

A precheck was set in place to prevent an event from being processed if it's expired or the SP has been recently slashed. It was not handling cases correctly where the SP has been recently slashed.

### Rationale

This issue needs to be resolved to prevent the challenger services from submitting the events for attestation. The attestation would not go through but it would cost gas to send the transaction.  

### Example

none

### Changes

Notable changes: 
none  

