### PR TITLE
chore: support reading db config from env

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -39,6 +39,9 @@ func NewApp(cfg *config.Config) *App {
 	if password == "" {
 		password = getDBPass(&cfg.DBConfig)
 	}
+	if username == "" || password == "" { // read password from ENV
+		username, password = config.GetDBUsernamePasswordFromEnv()
+	}
 
 	dbPath := fmt.Sprintf("%s:%s@%s", username, password, cfg.DBConfig.DBPath)
 

--- a/config/utils.go
+++ b/config/utils.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -43,4 +44,10 @@ func GetSecret(secretName, region string) (string, error) {
 		decodedBinarySecret = string(decodedBinarySecretBytes[:length])
 		return decodedBinarySecret, nil
 	}
+}
+
+func GetDBUsernamePasswordFromEnv() (string, string) {
+	username := os.Getenv("DB_USERNAME")
+	password := os.Getenv("DB_PASSWORD")
+	return username, password
 }


### PR DESCRIPTION
### Description

Support reading db username/password from env.

### Rationale

chore

### Example

```
export DB_USERNAME=dbuser
export DB_PASSWORD=dbpass
```

### Changes

Notable changes: 
* NA
